### PR TITLE
Fix "go get" installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ What makes simple-httpd different than it's Python alternative is that it suppor
 ## Installation
 
 ```
-go install github.com/briandowns/simple-httpd
+go get github.com/briandowns/simple-httpd
 ```
 or
 ```


### PR DESCRIPTION
Just a little fix for the README.