### PR TITLE
Miscellaneous fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,8 +25,11 @@ import (
 
 const version = "0.1"
 const name = "simple-httpd"
-const indexHTMLFile = "index.html"
 const pathSeperator = "/"
+var indexHTMLFiles = []string{
+	"index.html",
+	"index.htm",
+}
 
 const (
 	cert    = "cert.pem"
@@ -77,6 +80,15 @@ func (r requestData) Format(f fmt.State, c rune) {
 func setHeaders(w http.ResponseWriter) {
 	w.Header().Set("Server", name+pathSeperator+version)
 	w.Header().Add("Date", time.Now().Format(time.RFC822))
+}
+
+func isIndexFile(file string) bool {
+	for _, s := range indexHTMLFiles {
+		if s == file {
+			return true
+		}
+	}
+	return false
 }
 
 // ServeHTTP handles inbound requests
@@ -141,7 +153,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		files := make([]Data, 0, len(contents))
 		for _, entry := range contents {
-			if entry.Name() == indexHTMLFile {
+			if isIndexFile(entry.Name()) {
 				w.Header().Set("Content-type", "text/html; charset=UTF-8")
 				w.Header().Set("Content-Length", fmt.Sprintf("%v", entry.Size()))
 

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		UserAgent:  req.UserAgent(),
 	}
 
-	queryStr, err := url.QueryUnescape(req.RequestURI)
+	parsedURL, err := url.Parse(req.RequestURI)
 	if err != nil {
 		rd.Error = err.Error()
 		rd.Status = http.StatusInternalServerError
@@ -105,7 +105,8 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	fullpath := filepath.Join(h.Directory, queryStr[1:])
+	escapedPath := parsedURL.EscapedPath()
+	fullpath := filepath.Join(h.Directory, escapedPath[1:])
 
 	file, err := os.Open(fullpath)
 	if err != nil {
@@ -158,7 +159,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			file := Data{
 				Name:         entry.Name(),
 				LastModified: entry.ModTime().Format(time.RFC1123),
-				URI:          path.Join(queryStr, entry.Name()),
+				URI:          path.Join(escapedPath, entry.Name()),
 			}
 			if entry.IsDir() {
 				file.Name = entry.Name() + pathSeperator
@@ -175,9 +176,9 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			"files":           files,
 			"version":         gitSHA,
 			"port":            h.Port,
-			"relativePath":    queryStr,
+			"relativePath":    escapedPath,
 			"goVersion":       runtime.Version(),
-			"parentDirectory": path.Dir(queryStr),
+			"parentDirectory": path.Dir(escapedPath),
 		})
 
 		fmt.Println(rd)

--- a/main.go
+++ b/main.go
@@ -200,7 +200,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if mimetype := mime.TypeByExtension(path.Ext(file.Name())); mimetype != "" {
 		fmt.Println(mimetype)
-		w.Header().Set("Content-type", "text/html; charset=UTF-8")
+		w.Header().Set("Content-type", mimetype)
 	} else {
 		w.Header().Set("Content-type", "application/octet-stream")
 	}


### PR DESCRIPTION
Three things:
- The mimetype on responses wasn't getting set correctly, because the return value of mime.TypeByExtension() was never used
- I'm serving some pages which have javascript parsing GET parameters (eww, I know), which broke because the server was treating the whole thing as a filename, including the GET parameters.
- Allow multiple "index" HTML pages to be matched