### PR TITLE
Fixup directory handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,14 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	setHeaders(w)
 
 	if stat.IsDir() {
+		if escapedPath[len(escapedPath) - 1] != '/' {
+			// Redirect all directory requests to ensure they end with a slash
+			http.Redirect(w, req, escapedPath + "/", http.StatusFound)
+			rd.Status = http.StatusFound;
+			fmt.Println(rd)
+			return
+		}
+
 		contents, err := file.Readdir(-1)
 		if err != nil {
 			rd.Status = http.StatusInternalServerError
@@ -203,7 +211,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			"port":            h.Port,
 			"relativePath":    escapedPath,
 			"goVersion":       runtime.Version(),
-			"parentDirectory": path.Dir(escapedPath),
+			"parentDirectory": path.Clean(escapedPath + "/.."),
 		})
 
 		fmt.Println(rd)


### PR DESCRIPTION
Make two fixes to the way directories are handled:
 1) If a request to a directory doesn't end with a trailing slash,
    redirect to add a trailing slash
 2) Use path.Clean(escapedPath + "/..") to get the parent directory name

Without this, directory handling has problems:
 - If a directory _with_ an index file is requested _without_ a
   trailing slash, then all relative links within that index page
   will be missing that directory's name (and will be broken).
 - If a directory _without_ an index file is requested _with_ a
   trailing slash, then the resulting listing incorrectly lists
   the current directory as its parent.

The new behaviour is more consistent, and should be more reliable. It
also matches python SimpleHTTPServer.